### PR TITLE
Localization of Chinese丨中文本地化

### DIFF
--- a/docs/zh-Hans/自述文件.md
+++ b/docs/zh-Hans/自述文件.md
@@ -4,7 +4,7 @@
 
 [//]: # "\+\_==!|!=_=!|!==_/+/ ***不要在此行上方编辑*** /+/^^+#|#+^+#|#+^^\+\"
 
-# 利布蕾斯科尔应用
+# LibreScore 应用程序
 
 <div align="center">
 
@@ -12,11 +12,11 @@
 
 [![Discord](https://img.shields.io/discord/774491656643674122?color=5865F2&label=&labelColor=555555&logo=discord&logoColor=FFFFFF)](https://discord.gg/DKu7cUZ4XQ) [![Weblate（翻译）](https://librescore.ddns.net/widgets/librescore/-/app-librescore/svg-badge.svg)](https://librescore.ddns.net/engage/librescore) [![Github 全部发布版](https://img.shields.io/github/downloads/LibreScore/app-librescore/total.svg?label=Downloads)](https://github.com/LibreScore/app-librescore/releases/latest)
 
-下载利布蕾斯科尔应用
+下载 LibreScore 应用程序
 
 </div>
 
-> 免责声明：这不是官方认可的 MuseScore 产品
+> 免责声明：本项目与 MuseScore 官方产品无关。
 
 ## 下载
 


### PR DESCRIPTION
This document seems machine-translated. The name 'librescore' is wrongly translated by pronunciation 'li-bre-s-co-re'. In most cases, it should not be translated (eg. LibreOffice is exactly named LibreOffice in Chinese version).