### PR TITLE
Upgrade Flutter to 3.7.0

### DIFF
--- a/.github/workflows/build_app.yaml
+++ b/.github/workflows/build_app.yaml
@@ -40,7 +40,7 @@ Installation instructions are in the [README](https://github.com/LibreScore/${{ 
             - name: Install Flutter
               uses: subosito/flutter-action@v2
               with:
-                  flutter-version: "3.3.10"
+                  flutter-version: "3.7.0"
                   channel: "stable"
                   cache: true
                   cache-key: flutter


### PR DESCRIPTION
Flutter 3.7.0 has been released in the [stable channel](https://docs.flutter.dev/development/tools/sdk/releases).